### PR TITLE
[macOS] copy .dylib into .so

### DIFF
--- a/antic/antic/dune
+++ b/antic/antic/dune
@@ -31,7 +31,9 @@
        --with-pkg-config
        CFLAGS=-fPIC)
       (run make library -j)
-      (run make install)))
+      (run make install)
+      (system "if [ -f ../prefix/lib/libantic.dylib ]; then mv ../prefix/lib/libantic.dylib ../prefix/lib/libantic.so; fi")
+      ))
     (copy prefix/lib/libantic%{ext_dll} dllantic%{ext_dll})
     (copy prefix/lib/libantic%{ext_lib} libantic%{ext_lib})
     (copy prefix/include/antic/nf_elem.h nf_elem.h)

--- a/arb/dune
+++ b/arb/dune
@@ -99,7 +99,9 @@
        --with-pkg-config
        CFLAGS=-fPIC)
       (run make library -j)
-      (run make install)))
+      (run make install)
+      (system "if [ -f ../prefix/lib/libarb.dylib ]; then mv ../prefix/lib/libarb.dylib ../prefix/lib/libarb.so; fi")
+      ))
     (copy prefix/lib/libarb%{ext_dll} dllarb%{ext_dll})
     (copy prefix/lib/libarb%{ext_lib} libarb%{ext_lib})
     (copy prefix/include/dirichlet.h dirichlet.h)

--- a/calcium/lib/dune
+++ b/calcium/lib/dune
@@ -65,7 +65,9 @@
        --with-pkg-config
        CFLAGS=-fPIC)
       (run make library -j)
-      (run make install)))
+      (run make install)
+      (system "if [ -f ../prefix/lib/libcalcium.dylib ]; then mv ../prefix/lib/libcalcium.dylib ../prefix/lib/libcalcium.so; fi")
+      ))
     (copy prefix/lib/libcalcium%{ext_dll} dllcalcium%{ext_dll})
     (copy prefix/lib/libcalcium%{ext_lib} libcalcium%{ext_lib})
     (copy prefix/include/calcium/qqbar.h qqbar.h)

--- a/flint/flint/dune
+++ b/flint/flint/dune
@@ -139,7 +139,9 @@
      (progn
       (run ./configure --prefix=../prefix CFLAGS=-fPIC --with-pkg-config)
       (run make library -j)
-      (run make install)))
+      (run make install)
+      (system "if [ -f ../prefix/lib/libflint.dylib ]; then mv ../prefix/lib/libflint.dylib ../prefix/lib/libflint.so; fi")
+      ))
     (copy prefix/lib/libflint%{ext_lib} libflint%{ext_lib})
     (copy prefix/lib/libflint%{ext_dll} dllflint%{ext_dll})
     (copy prefix/include/flint/aprcl.h aprcl.h)


### PR DESCRIPTION
Workaround dune issue with `ext_dll='.so'` under macOS.