### PR TITLE
Adjust build sys for flintv3 (and also archlinux)

### DIFF
--- a/antic/dune
+++ b/antic/dune
@@ -1,6 +1,9 @@
 (library
  (name antic)
  (public_name antic)
- (c_library_flags -lantic)
+ (c_library_flags
+  (:include ../configure/flint_libs.sexp)
+  (:include ../configure/antic_libs.sexp)
+  )
  (libraries zarith flint threads)
  (flags -w -9-27))

--- a/antic/dune
+++ b/antic/dune
@@ -3,7 +3,6 @@
  (public_name antic)
  (c_library_flags
   (:include ../configure/flint_libs.sexp)
-  (:include ../configure/antic_libs.sexp)
-  )
+  (:include ../configure/antic_libs.sexp))
  (libraries zarith flint threads)
  (flags -w -9-27))

--- a/arb/dune
+++ b/arb/dune
@@ -2,13 +2,16 @@
  (name arb)
  (public_name arb)
  (c_library_flags
-  -lflint
-  (:include ../configure/arb_cflag.sexp))
+  (:include ../configure/common_libs.sexp)
+  (:include ../configure/flint_libs.sexp)
+  (:include ../configure/arb_libs.sexp))
  (foreign_stubs
   (language c)
   (names ocaml_acb_utils)
   (flags
-   (:include ../configure/c_flags.sexp)
+   (:include ../configure/common_cflags.sexp)
+   (:include ../configure/flint_cflags.sexp)
+   (:include ../configure/arb_cflags.sexp)
    :standard))
  (libraries zarith flint threads)
  (flags -w -9-27)
@@ -18,11 +21,14 @@
    (vendored
     (c_flags
      "-Werror=implicit-function-declaration"
-     (:include ../configure/c_flags.sexp)
+     (:include ../configure/common_cflags.sexp)
+     (:include ../configure/flint_cflags.sexp)
+     (:include ../configure/arb_cflags.sexp)
      :standard)
     (c_library_flags
-     (:include ../configure/libs.sexp)
-     "-lgmp -lmpfr")))
+     (:include ../configure/common_libs.sexp)
+     (:include ../configure/flint_libs.sexp)
+     (:include ../configure/arb_libs.sexp))))
   (headers
    (include "acb.h" "string.h"))
   (type_description

--- a/calcium/dune
+++ b/calcium/dune
@@ -2,15 +2,20 @@
  (name calcium)
  (public_name calcium)
  (c_library_flags
-  -lflint
-  (:include ../configure/arb_cflag.sexp)
-  -lantic
-  -lcalcium)
+  (:include ../configure/common_libs.sexp)
+  (:include ../configure/flint_libs.sexp)
+  (:include ../configure/arb_libs.sexp)
+  (:include ../configure/antic_libs.sexp)
+  (:include ../configure/calcium_libs.sexp))
  (foreign_stubs
   (language c)
   (names ocaml_calcium_utils)
   (flags
-   (:include ../configure/c_flags.sexp)
+   (:include ../configure/common_cflags.sexp)
+   (:include ../configure/flint_cflags.sexp)
+   (:include ../configure/arb_cflags.sexp)
+   (:include ../configure/antic_cflags.sexp)
+   (:include ../configure/calcium_cflags.sexp)
    :standard))
  (libraries zarith flint arb antic threads)
  (flags -w -9-27)
@@ -19,19 +24,21 @@
   (build_flags_resolver
    (vendored
     (c_flags
-     "-Iflint"
-     "-Iantic"
-     "-Icalcium"
      "-Werror=implicit-function-declaration"
-     (:include ../configure/c_flags.sexp)
+     (:include ../configure/common_cflags.sexp)
+     (:include ../configure/flint_cflags.sexp)
+     (:include ../configure/arb_cflags.sexp)
+     (:include ../configure/antic_cflags.sexp)
+     (:include ../configure/calcium_cflags.sexp)
      :standard)
     (c_library_flags
-     (:include ../configure/libs.sexp)
-     "-lgmp -lmpfr -lflint"
-     (:include ../configure/arb_cflag.sexp)
-     "-lantic -lcalcium")))
+     (:include ../configure/common_libs.sexp)
+     (:include ../configure/flint_libs.sexp)
+     (:include ../configure/arb_libs.sexp)
+     (:include ../configure/antic_libs.sexp)
+     (:include ../configure/calcium_libs.sexp))))
   (headers
-   (include "calcium/ca.h" "string.h"))
+   (include "ca.h" "string.h"))
   (type_description
    (instance Type)
    (functor Type_description))

--- a/calcium/ocaml_calcium_utils.c
+++ b/calcium/ocaml_calcium_utils.c
@@ -1,4 +1,4 @@
-#include "calcium/ca.h"
+#include "ca.h"
 #include "ctypes_cstubs_internals.h"
 #include <stdio.h>
 

--- a/configure/dune
+++ b/configure/dune
@@ -1,13 +1,29 @@
 (executables
- (names discover find_arb)
+ (names find_common find_flint find_arb find_antic find_calcium)
+ (modules find_common find_flint find_arb find_antic find_calcium util)
  (libraries dune-configurator))
 
 (rule
- (targets c_flags.sexp libs.sexp)
+ (targets common_cflags.sexp common_libs.sexp)
  (action
-  (run ./discover.exe)))
+  (run ./find_common.exe)))
 
 (rule
- (targets arb_cflag.sexp)
+ (targets flint_cflags.sexp flint_libs.sexp)
+ (action
+  (run ./find_flint.exe)))
+
+(rule
+ (targets arb_cflags.sexp arb_libs.sexp)
  (action
   (run ./find_arb.exe)))
+
+(rule
+ (targets antic_cflags.sexp antic_libs.sexp)
+ (action
+  (run ./find_antic.exe)))
+
+(rule
+ (targets calcium_cflags.sexp calcium_libs.sexp)
+ (action
+  (run ./find_calcium.exe)))

--- a/configure/find_antic.ml
+++ b/configure/find_antic.ml
@@ -32,7 +32,7 @@ let () =
   C.main ~name:"find_antic" (fun c ->
       let libs, cflags =
         match version c with
-        | `Antic2 -> ([ "-lantic" ], [])
+        | `Antic2 -> ([ "-lantic" ], [ "-I/usr/include/antic" ])
         | `Flint3 -> ([], [ "-I/usr/include/flint" ])
       in
       C.Flags.write_sexp "antic_cflags.sexp" cflags;

--- a/configure/find_antic.ml
+++ b/configure/find_antic.ml
@@ -14,27 +14,27 @@ module C = Configurator.V1
 
    These are the different situations:
    - on version <2 (and distros such as Debian):
-     + arb headers are directly in `/usr/include`
-     + arb lib file is libflint-arb.so
+     + antic headers are in `/usr/include/antic`
+     + antic lib file is libantic.so
    - on version 3 (and distros such as archlinux):
-     + arb headers are in `/usr/include/flint`
-     + arb library file does not exist (included in flint.so)
+     + antic headers are in `/usr/include/flint`
+     + antic library file does not exist (included in flint.so)
 *)
 
-(* Test the location of the `arb.h` header to determine the
+(* Test the location of the `qfb.h` header to determine the
    current situation *)
 let version c =
-  if Util.is_header_available c "arb.h" then `Arb2
-  else if Util.is_header_available c "flint/arb.h" then `Flint3
-  else C.die "Could not find the `arb` library"
+  if Util.is_header_available c "antic/qfb.h" then `Antic2
+  else if Util.is_header_available c "flint/qfb.h" then `Flint3
+  else C.die "Could not find the `antic` library"
 
 let () =
-  C.main ~name:"find_arb" (fun c ->
+  C.main ~name:"find_antic" (fun c ->
       let libs, cflags =
         match version c with
-        | `Arb2 -> ([ "-lflint-arb" ], [])
+        | `Antic2 -> ([ "-lantic" ], [])
         | `Flint3 -> ([], [ "-I/usr/include/flint" ])
       in
-      C.Flags.write_sexp "arb_cflags.sexp" cflags;
-      C.Flags.write_sexp "arb_libs.sexp" libs;
+      C.Flags.write_sexp "antic_cflags.sexp" cflags;
+      C.Flags.write_sexp "antic_libs.sexp" libs;
       ())

--- a/configure/find_calcium.ml
+++ b/configure/find_calcium.ml
@@ -32,7 +32,7 @@ let () =
   C.main ~name:"find_calcium" (fun c ->
       let libs, cflags =
         match version c with
-        | `Calcium2 -> ([ "-lcalcium" ], [])
+        | `Calcium2 -> ([ "-lcalcium" ], [ "-I/usr/include/calcium" ])
         | `Flint3 -> ([], [ "-I/usr/include/flint" ])
       in
       C.Flags.write_sexp "calcium_cflags.sexp" cflags;

--- a/configure/find_calcium.ml
+++ b/configure/find_calcium.ml
@@ -14,27 +14,27 @@ module C = Configurator.V1
 
    These are the different situations:
    - on version <2 (and distros such as Debian):
-     + arb headers are directly in `/usr/include`
-     + arb lib file is libflint-arb.so
+     + antic headers are in `/usr/include/antic`
+     + antic lib file is libantic.so
    - on version 3 (and distros such as archlinux):
-     + arb headers are in `/usr/include/flint`
-     + arb library file does not exist (included in flint.so)
+     + calcium headers are in `/usr/include/flint`
+     + calcium library file does not exist (included in flint.so)
 *)
 
-(* Test the location of the `arb.h` header to determine the
+(* Test the location of the `qfb.h` header to determine the
    current situation *)
 let version c =
-  if Util.is_header_available c "arb.h" then `Arb2
-  else if Util.is_header_available c "flint/arb.h" then `Flint3
-  else C.die "Could not find the `arb` library"
+  if Util.is_header_available c "calcium/calcium.h" then `Calcium2
+  else if Util.is_header_available c "flint/calcium.h" then `Flint3
+  else C.die "Could not find the `calcium` library"
 
 let () =
-  C.main ~name:"find_arb" (fun c ->
+  C.main ~name:"find_calcium" (fun c ->
       let libs, cflags =
         match version c with
-        | `Arb2 -> ([ "-lflint-arb" ], [])
+        | `Calcium2 -> ([ "-lcalcium" ], [])
         | `Flint3 -> ([], [ "-I/usr/include/flint" ])
       in
-      C.Flags.write_sexp "arb_cflags.sexp" cflags;
-      C.Flags.write_sexp "arb_libs.sexp" libs;
+      C.Flags.write_sexp "calcium_cflags.sexp" cflags;
+      C.Flags.write_sexp "calcium_libs.sexp" libs;
       ())

--- a/configure/find_common.ml
+++ b/configure/find_common.ml
@@ -4,7 +4,9 @@ let () =
   C.main ~name:"discover" (fun c ->
       let cflags, libs =
         match C.Pkg_config.get c with
-        | None -> ([], [])
+        | None ->
+            (* sane defaults in the absence of pkg-config *)
+            ([ "-lgmp"; "-lmpfr" ], [])
         | Some pc ->
             let flags ~package =
               match C.Pkg_config.query pc ~package with
@@ -13,9 +15,8 @@ let () =
             in
             let gmp = flags ~package:"gmp" in
             let mpfr = flags ~package:"mpfr" in
-
             (fst gmp @ fst mpfr, snd gmp @ snd mpfr)
       in
 
-      C.Flags.write_sexp "c_flags.sexp" cflags;
-      C.Flags.write_sexp "libs.sexp" libs)
+      C.Flags.write_sexp "common_cflags.sexp" cflags;
+      C.Flags.write_sexp "common_libs.sexp" libs)

--- a/configure/find_flint.ml
+++ b/configure/find_flint.ml
@@ -14,27 +14,18 @@ module C = Configurator.V1
 
    These are the different situations:
    - on version <2 (and distros such as Debian):
-     + arb headers are directly in `/usr/include`
-     + arb lib file is libflint-arb.so
+     + flint headers are in `/usr/include/flint`
+     + flint lib file is libflint.so
    - on version 3 (and distros such as archlinux):
-     + arb headers are in `/usr/include/flint`
-     + arb library file does not exist (included in flint.so)
+     + flint headers are in `/usr/include/flint`
+     + flint lib file is libflint.so
 *)
 
 (* Test the location of the `arb.h` header to determine the
    current situation *)
-let version c =
-  if Util.is_header_available c "arb.h" then `Arb2
-  else if Util.is_header_available c "flint/arb.h" then `Flint3
-  else C.die "Could not find the `arb` library"
-
 let () =
-  C.main ~name:"find_arb" (fun c ->
-      let libs, cflags =
-        match version c with
-        | `Arb2 -> ([ "-lflint-arb" ], [])
-        | `Flint3 -> ([], [ "-I/usr/include/flint" ])
-      in
-      C.Flags.write_sexp "arb_cflags.sexp" cflags;
-      C.Flags.write_sexp "arb_libs.sexp" libs;
+  C.main ~name:"find_flint" (fun _c ->
+      let libs, cflags = ([ "-lflint" ], [ "-I/usr/include/flint" ]) in
+      C.Flags.write_sexp "flint_cflags.sexp" cflags;
+      C.Flags.write_sexp "flint_libs.sexp" libs;
       ())

--- a/configure/util.ml
+++ b/configure/util.ml
@@ -1,0 +1,15 @@
+module C = Configurator.V1
+
+let is_header_available c ?(c_flags = []) h =
+  let c_main = Format.asprintf {|#include "%s"|} h in
+  let c_flags = "-c" :: c_flags in
+  C.c_test c ~c_flags c_main
+
+let find_working_cflag ~name ~c flags =
+  let dummy_c_main = {|int main() { return 0; }|} in
+  let rec aux = function
+    | [] -> C.die "Could not find an available c libname for %s" name
+    | cflag :: r ->
+        if C.c_test c ~c_flags:[ cflag ] dummy_c_main then cflag else aux r
+  in
+  aux flags

--- a/flint/dune
+++ b/flint/dune
@@ -1,12 +1,15 @@
 (library
  (name flint)
  (public_name flint)
- (c_library_flags "-lflint")
+ (c_library_flags
+  (:include ../configure/common_libs.sexp)
+  (:include ../configure/flint_libs.sexp))
  (foreign_stubs
   (language c)
   (names ocaml_flint_utils)
   (flags
-   (:include ../configure/c_flags.sexp)
+   (:include ../configure/common_cflags.sexp)
+   (:include ../configure/flint_cflags.sexp)
    "-Werror=implicit-function-declaration"
    :standard)
   (include_dirs
@@ -19,13 +22,14 @@
    (vendored
     (c_flags
      "-Werror=implicit-function-declaration"
-     (:include ../configure/c_flags.sexp)
+     (:include ../configure/common_cflags.sexp)
+     (:include ../configure/flint_cflags.sexp)
      :standard)
     (c_library_flags
-     (:include ../configure/libs.sexp)
-     "-lgmp -lmpfr -lflint")))
+     (:include ../configure/common_libs.sexp)
+     (:include ../configure/flint_libs.sexp))))
   (headers
-   (include "flint/fmpz.h" "flint/fmpq.h" "flint/fmpz_poly.h" "string.h"))
+   (include "fmpz.h" "fmpq.h" "fmpz_poly.h" "string.h"))
   (type_description
    (instance Type)
    (functor Type_description))

--- a/flint/ocaml_flint_utils.c
+++ b/flint/ocaml_flint_utils.c
@@ -1,5 +1,5 @@
-#include "flint/fmpz.h"
-#include "flint/fmpz_poly.h"
+#include "fmpz.h"
+#include "fmpz_poly.h"
 #include "ctypes_cstubs_internals.h"
 #include "gmp.h"
 #include "zarith.h"


### PR DESCRIPTION
Flint version 3 [incorporates arb, antic and calcium](https://github.com/flintlib/flint#overview) (and is now the released version on archlinux), so a few things have to change in the build system if we want to be able to build against the newest releases.

We now have quite a few more configure scripts, basically one for each c library, plus one for the common ones (`gmp`, `mpfr`). Each script is responsible for providing the list of cflags and lib flags to use when compiling c code that use their library. Additionally, since header files can now be in different directories (e.g. `calcium/calcium.h` or `flint/calcium.h`), this PR makes it so that we try to always refer to header files by their basename, and add the correct `-I` flags through the cflags, which should hopefully make things a bit simpler (assuming we do not use libraries with name clashes).

I have tested this on Arch with flint v3. Will wait for CI to see if I have broken the build for other distros (and older flint versions).