### PR TITLE
build: Include gmp.h before FLINT headers

### DIFF
--- a/src/ocaml_flint_utils.c
+++ b/src/ocaml_flint_utils.c
@@ -1,9 +1,12 @@
+// gmp must be included before flint for some functions, such as
+// _fmpz_promote_val, to be available; see e.g.
+// https://flintlib.org/doc/fmpz.html#c._fmpz_promote
+#include "gmp.h"
 #include "flint/fmpz.h"
 #include "flint/fmpz_poly.h"
 #include "flint/acb.h"
 #include "flint/ca.h"
 #include "ctypes_cstubs_internals.h"
-#include "gmp.h"
 #include "zarith.h"
 #include <stdio.h>
 


### PR DESCRIPTION
Otherwise, some functions such as _fmpz_promote are not available; see the FLINT documentation:
https://flintlib.org/doc/fmpz.html#c._fmpz_promote

This has changed in FLINT 3.2.0, which no longer includes gmp.h in headers: https://flintlib.org/doc/history.html#flint-3-2-0